### PR TITLE
Adds a badge and label to the AddonButton

### DIFF
--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -45,7 +45,12 @@ const CustomDialogAddon = () => (
 const ContextTestAddon = () => {
   const { message } = React.useContext(Context)
   return (
-    <AddonDialogButton icon={<Truck />} tooltip="Tests context">
+    <AddonDialogButton
+      icon={<Truck />}
+      label="Test context"
+      tooltip="Tests if the context provider can be used within the button component."
+      badge={1}
+    >
       <p>{message}</p>
     </AddonDialogButton>
   )

--- a/src/components/AddonButton.tsx
+++ b/src/components/AddonButton.tsx
@@ -6,18 +6,33 @@ export interface AddonButtonProps extends React.ComponentProps<"button"> {
    * Displayed in a tooltip on button hover. Also used as the button's default aria-label value.
    */
   tooltip: string
+  /**
+   * Adds a label to the button for accessibility purposes.
+   */
+  label?: string
+  /**
+   * Shows a badge on the button.
+   * If a number is provided, that number will display in the badge.
+   *
+   * @default false
+   */
+  badge?: boolean | number
 }
 
 export const AddonButton: React.FC<AddonButtonProps> = ({
   icon,
   tooltip,
   children,
+  badge = false,
+  label = "",
   ...buttonProps
 }) => (
   <li>
     <button aria-label={tooltip} type="button" {...buttonProps}>
       {icon}
       <span className="ladle-addon-tooltip">{tooltip}</span>
+      {label && <label>{label}</label>}
+      {badge && <div className="ladle-badge">{badge}</div>}
     </button>
     {children}
   </li>


### PR DESCRIPTION
Adds a badge that can display a change/notification/etc count. Also adds a label for accessibility purposes (I assume).
<img width="127" alt="image" src="https://github.com/hiddenist/ladle-inject-custom-addons/assets/563879/c2ca4305-3cab-42d7-af7d-f4d084f1c5bf">
