### PR TITLE
Fixes exports and example build after version upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,11 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
+
   pull_request:
-    types: [opened, synchronize]
+    types: ["opened", "synchronize"]
+
   workflow_dispatch:
     inputs:
       lint_fix:
@@ -15,33 +16,38 @@ on:
         default: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-ci
   cancel-in-progress: true
 
 env:
-  LINT_FIX: ${{ fromJSON(inputs.lint_fix || 'false') || github.event_name == 'pull_request' && github.head_ref != 'main' }}
+  fixLintingErrors: ${{ fromJSON(inputs.lint_fix || 'false') || github.event_name == 'pull_request' && github.head_ref != 'main' }}
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: install pnpm
-        run: |
-          npm i -g pnpm
-          pnpm -v
+
       - uses: actions/setup-node@v4
         with:
           cache: "pnpm"
           node-version-file: ".nvmrc"
-      - run: pnpm install
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.4.0
+          run_install: true
+
       - run: pnpm typecheck
+
       - run: pnpm lint
-        if: ${{ ! fromJSON(env.LINT_FIX) }}
+        if: ${{ ! fromJSON(env.fixLintingErrors) }}
+
       - run: pnpm lint:fix
-        if: ${{ fromJSON(env.LINT_FIX) }}
+        if: ${{ fromJSON(env.fixLintingErrors) }}
+
       - name: Commit linter fixes
         uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 #v5
-        if: ${{ fromJSON(env.LINT_FIX) }}
+        if: ${{ fromJSON(env.fixLintingErrors) }}
         with:
-          commit_message: "automated commit: pnpm lint:fix"
+          commit_message: "pnpm lint:fix"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          cache: "pnpm"
-          node-version-file: ".nvmrc"
-
       - uses: pnpm/action-setup@v4
         with:
           version: 9.4.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4
         with:
           version: 9.4.0
           run_install: true
-
-      - name: Build package
-        run: pnpm build
 
       - name: Build Ladle static content
         run: pnpm ladle build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 9.4.0
+          run_install: true
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Build Ladle static content
+        run: pnpm ladle build
+        env:
+          BASE_URL: ${{ github.event.repository.name }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "build"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { AlertCircle, ThumbsUp, Truck } from "react-feather"
+import "./style.css"
 
 import {
   CustomGlobalProvider,
@@ -23,8 +24,28 @@ export const Provider: CustomGlobalProvider<MyCustomAddonConfig> = ({
   config,
   children,
 }) => (
-  <Context.Provider value={{ message: "in context" }}>
-    {children}
+  <Context.Provider
+    value={{
+      message: (
+        <>
+          <p>
+            This message being displayed shows that the addon button is able to
+            receive data from a context provider. Yay!
+          </p>
+          <p>
+            This message is populated from a context provided in the{" "}
+            <code>CustomGlobalProvider</code> component. If you want to know
+            more about how it works, check out the
+            <a href="https://github.com/hiddenist/ladle-inject-custom-addons/blob/main/.ladle/components.tsx">
+              components.tsx
+            </a>{" "}
+            source code.
+          </p>
+        </>
+      ),
+    }}
+  >
+    <div style={{ fontFamily: "Arial, Helvetica, sans-serif" }}>{children}</div>
     <CustomDialogAddon />
     <ContextTestAddon position={2} />
     {config.addons.customAddon.enabled && (
@@ -38,7 +59,12 @@ export const Provider: CustomGlobalProvider<MyCustomAddonConfig> = ({
 )
 
 const Context = React.createContext({
-  message: "not in context",
+  message: (
+    <p>
+      If you can see this message, it means that the addon is not receiving data
+      from the context provider in the CustomGlobalProvider component. Dang.
+    </p>
+  ),
 })
 
 const PrependedHelloAddon = ({ position = 0 }) => {
@@ -80,12 +106,11 @@ const ContextTestAddon = ({ position = 0 }) => {
   return (
     <AddonDialogButton
       icon={<Truck />}
-      label="Test context"
-      tooltip="Tests if the context provider can be used within the button component."
-      badge={1}
+      label="Addons with Context"
+      tooltip="Demonstrates that addon buttons are able to inherit parent context."
       position={position}
     >
-      <p>{message}</p>
+      {message}
     </AddonDialogButton>
   )
 }

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Truck, AlertCircle } from "react-feather"
+import { AlertCircle, ThumbsUp, Truck } from "react-feather"
 
 import {
   CustomGlobalProvider,
@@ -15,6 +15,7 @@ const packageName = "ladle-inject-custom-addons"
 interface MyCustomAddonConfig {
   customAddon: {
     enabled: boolean
+    customMessage: string
   }
 }
 
@@ -28,8 +29,8 @@ export const Provider: CustomGlobalProvider<MyCustomAddonConfig> = ({
     <ContextTestAddon position={2} />
     {config.addons.customAddon.enabled && (
       <AddonButton
-        icon={<ExampleLadleIcon />}
-        tooltip="this addon must be enabled in config.mjs to show up"
+        icon={<ThumbsUp />}
+        tooltip={`This addon must be enabled in config.mjs to show up. ${config.addons.customAddon.customMessage}`}
       />
     )}
     <PrependedHelloAddon position={-1} />

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -10,6 +10,7 @@ import {
 } from "ladle-inject-custom-addons"
 
 import { GettingStarted } from "./components/GettingStarted"
+import { Context, contextMessage } from "./components/ContextExample"
 
 const packageName = "ladle-inject-custom-addons"
 
@@ -24,48 +25,23 @@ export const Provider: CustomGlobalProvider<MyCustomAddonConfig> = ({
   config,
   children,
 }) => (
-  <Context.Provider
-    value={{
-      message: (
-        <>
-          <p>
-            This message being displayed shows that the addon button is able to
-            receive data from a context provider. Yay!
-          </p>
-          <p>
-            This message is populated from a context provided in the{" "}
-            <code>CustomGlobalProvider</code> component. If you want to know
-            more about how it works, check out the
-            <a href="https://github.com/hiddenist/ladle-inject-custom-addons/blob/main/.ladle/components.tsx">
-              components.tsx
-            </a>{" "}
-            source code.
-          </p>
-        </>
-      ),
-    }}
-  >
-    <div style={{ fontFamily: "Arial, Helvetica, sans-serif" }}>{children}</div>
+  <Context.Provider value={{ message: contextMessage }}>
+    {children}
+
     <CustomDialogAddon />
+
     <ContextTestAddon position={2} />
+
     {config.addons.customAddon.enabled && (
       <AddonButton
         icon={<ThumbsUp />}
         tooltip={`This addon must be enabled in config.mjs to show up. ${config.addons.customAddon.customMessage}`}
       />
     )}
+
     <PrependedHelloAddon position={-1} />
   </Context.Provider>
 )
-
-const Context = React.createContext({
-  message: (
-    <p>
-      If you can see this message, it means that the addon is not receiving data
-      from the context provider in the CustomGlobalProvider component. Dang.
-    </p>
-  ),
-})
 
 const PrependedHelloAddon = ({ position = 0 }) => {
   const [packageManager, setPackageManager] = React.useState<string>("")
@@ -73,16 +49,13 @@ const PrependedHelloAddon = ({ position = 0 }) => {
     <AddonDialogButton
       icon={<ExampleLadleIcon />}
       tooltip="Shows info about this package."
-      style={{ display: "grid", gap: 16 }}
       position={position}
     >
       <p>
         <strong>{packageName}</strong>
       </p>
       <p>Add your own components in the Ladle addon panel!</p>
-      <div style={{ fontSize: 50, textAlign: "center", marginBottom: 16 }}>
-        ✨🐙✨
-      </div>
+      <div className="octomoji">✨🐙✨</div>
       <GettingStarted
         packageName={packageName}
         packageManager={packageManager}
@@ -101,7 +74,7 @@ const CustomDialogAddon = ({ position = 0 }) => (
   />
 )
 
-const ContextTestAddon = ({ position = 0 }) => {
+export const ContextTestAddon = ({ position = 0 }) => {
   const { message } = React.useContext(Context)
   return (
     <AddonDialogButton

--- a/.ladle/components.tsx
+++ b/.ladle/components.tsx
@@ -33,10 +33,18 @@ export const Provider: CustomGlobalProvider<MyCustomAddonConfig> = ({
     <ContextTestAddon position={2} />
 
     {config.addons.customAddon.enabled && (
-      <AddonButton
+      <AddonDialogButton
         icon={<ThumbsUp />}
-        tooltip={`This addon must be enabled in config.mjs to show up. ${config.addons.customAddon.customMessage}`}
-      />
+        label="Use custom configuration"
+        tooltip="Uses a custom configuration to show a custom message."
+      >
+        <p>
+          This addon is set up so that it must be enabled in the{" "}
+          <code>config.mjs</code> file to show up, similar to the built-in Ladle
+          addons.
+        </p>
+        <p>{config.addons.customAddon.customMessage}</p>
+      </AddonDialogButton>
     )}
 
     <PrependedHelloAddon position={-1} />
@@ -48,6 +56,7 @@ const PrependedHelloAddon = ({ position = 0 }) => {
   return (
     <AddonDialogButton
       icon={<ExampleLadleIcon />}
+      label="Show package info"
       tooltip="Shows info about this package."
       position={position}
     >
@@ -68,6 +77,7 @@ const PrependedHelloAddon = ({ position = 0 }) => {
 const CustomDialogAddon = ({ position = 0 }) => (
   <AddonButton
     icon={<AlertCircle />}
+    label="Show an alert"
     onClick={() => alert("hello!")}
     tooltip="Shows an alert to say hello."
     position={position}
@@ -79,7 +89,7 @@ export const ContextTestAddon = ({ position = 0 }) => {
   return (
     <AddonDialogButton
       icon={<Truck />}
-      label="Addons with Context"
+      label="Use a context"
       tooltip="Demonstrates that addon buttons are able to inherit parent context."
       position={position}
     >

--- a/.ladle/components/ContextExample.tsx
+++ b/.ladle/components/ContextExample.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+
+export const Context = React.createContext({
+  message: (
+    <p>
+      If you can see this message, it means that the addon is not receiving data
+      from the context provider in the CustomGlobalProvider component. Dang.
+    </p>
+  ),
+})
+
+export const contextMessage = (
+  <>
+    <p>
+      This message being displayed shows that the addon button is able to
+      receive data from a context provider. Yay!
+    </p>
+    <p>
+      This message is populated from a context provided in the{" "}
+      <code>CustomGlobalProvider</code> component. If you want to know more
+      about how it works, check out the
+      <a href="https://github.com/hiddenist/ladle-inject-custom-addons/blob/main/.ladle/components.tsx">
+        components.tsx
+      </a>{" "}
+      source code.
+    </p>
+  </>
+)

--- a/.ladle/components/ContextExample.tsx
+++ b/.ladle/components/ContextExample.tsx
@@ -18,11 +18,11 @@ export const contextMessage = (
     <p>
       This message is populated from a context provided in the{" "}
       <code>CustomGlobalProvider</code> component. If you want to know more
-      about how it works, check out the
+      about how it works, check out the{" "}
       <a href="https://github.com/hiddenist/ladle-inject-custom-addons/blob/main/.ladle/components.tsx">
         components.tsx
       </a>{" "}
-      source code.
+      source code on GitHub.
     </p>
   </>
 )

--- a/.ladle/components/PlusOneAnimated.tsx
+++ b/.ladle/components/PlusOneAnimated.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+
+const PlusOne = () => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: "100%",
+        animation: "plus-one 1s forwards",
+        fontWeight: "bold",
+        fontSize: 12,
+        color: "rgba(10, 60, 90, 0.9)",
+        backgroundColor: "rgba(255, 255, 255, 0.2)",
+        borderRadius: 4,
+      }}
+    >
+      +1
+    </div>
+  )
+}
+
+export const usePlusOneAnimated = () => {
+  const [elements, setElements] = React.useState<React.ReactNode[]>([])
+
+  const addPlusOne = React.useCallback(() => {
+    const element = <PlusOne key={Date.now()} />
+    setElements((elems) => [...elems, element])
+    setTimeout(() => {
+      setElements((elems) => elems.filter((e) => e !== element))
+    }, 1000)
+  }, [])
+
+  return {
+    addPlusOne,
+    elements,
+  }
+}

--- a/.ladle/components/PlusOneAnimated.tsx
+++ b/.ladle/components/PlusOneAnimated.tsx
@@ -1,22 +1,7 @@
 import React from "react"
 
 const PlusOne = () => {
-  return (
-    <div
-      style={{
-        position: "absolute",
-        bottom: "100%",
-        animation: "plus-one 1s forwards",
-        fontWeight: "bold",
-        fontSize: 12,
-        color: "rgba(10, 60, 90, 0.9)",
-        backgroundColor: "rgba(255, 255, 255, 0.2)",
-        borderRadius: 4,
-      }}
-    >
-      +1
-    </div>
-  )
+  return <div className="plus-one">+1</div>
 }
 
 export const usePlusOneAnimated = () => {

--- a/.ladle/config.mjs
+++ b/.ladle/config.mjs
@@ -8,7 +8,7 @@ export default {
       enabled: false,
     },
     theme: {
-      enabled: false,
+      enabled: true,
     },
     mode: {
       enabled: false,

--- a/.ladle/config.mjs
+++ b/.ladle/config.mjs
@@ -14,7 +14,8 @@ export default {
       enabled: false,
     },
     customAddon: {
-      enabled: false,
+      enabled: true,
+      customMessage: "You can also add custom values to the config file!",
     },
   },
 }

--- a/.ladle/config.mjs
+++ b/.ladle/config.mjs
@@ -1,5 +1,8 @@
+const baseUrl = process.env["BASE_URL"] || "/"
+
 export default {
   stories: ["{src,.ladle}/**/*.stories.{js,jsx,ts,tsx}"],
+  base: baseUrl,
   addons: {
     ladle: {
       enabled: false,

--- a/.ladle/example.stories.tsx
+++ b/.ladle/example.stories.tsx
@@ -1,7 +1,10 @@
 import React from "react"
 import type { Story } from "@ladle/react"
+import { PlusCircle } from "react-feather"
+import { AddonButton } from "ladle-inject-custom-addons"
+import { usePlusOneAnimated } from "./components/PlusOneAnimated"
 
-export const Simple: Story = () => (
+export const Home: Story = () => (
   <div>
     <h1>Welcome</h1>
     <p>
@@ -10,3 +13,44 @@ export const Simple: Story = () => (
     </p>
   </div>
 )
+
+export const StoryWithAddon: Story = () => {
+  const [clickCount, setClickCount] = React.useState(0)
+
+  const { elements, addPlusOne } = usePlusOneAnimated()
+
+  return (
+    <div>
+      <h1>This story has its own addon button</h1>
+      <p>
+        In addition to creating addon buttons in the global context, you can
+        also create addon buttons that only show up for specific stories!
+      </p>
+      <p>
+        <h2>
+          You have clicked the button {clickCount} time{clickCount != 1 && "s"}
+        </h2>
+      </p>
+      <p>
+        Curious how it's done? Find the source code button and take a look at
+        the code for this story!
+      </p>
+
+      <AddonButton
+        icon={
+          <>
+            <PlusCircle />
+            {elements}
+          </>
+        }
+        tooltip="Increment the click count for this story"
+        position={10}
+        badge={true}
+        onClick={() => {
+          addPlusOne()
+          setClickCount((c) => c + 1)
+        }}
+      />
+    </div>
+  )
+}

--- a/.ladle/example.stories.tsx
+++ b/.ladle/example.stories.tsx
@@ -5,11 +5,38 @@ import { AddonButton } from "ladle-inject-custom-addons"
 import { usePlusOneAnimated } from "./components/PlusOneAnimated"
 
 export const Home: Story = () => (
-  <div>
-    <h1>Welcome</h1>
+  <div className="home">
+    <h1>ladle-inject-custom-addons</h1>
+    <div className="github-badges">
+      <a href="https://npmjs.com/package/ladle-inject-custom-addons">
+        <img
+          src="https://img.shields.io/npm/v/ladle-inject-custom-addons.svg"
+          alt="npm package"
+        />
+      </a>
+      <a href="https://github.com/hiddenist/ladle-inject-custom-addons/actions/workflows/ci.yml">
+        <img
+          src="https://github.com/hiddenist/ladle-inject-custom-addons/actions/workflows/ci.yml/badge.svg?branch=main"
+          alt="build status"
+        />
+      </a>
+    </div>
+    <img
+      width="686"
+      alt="A screenshot of the Ladle addon bar, with a dialog box displaying text: 'ladle-inject-custom-addons' Add your own components in the Ladle addon panel! ✨🐙✨"
+      src="https://github.com/hiddenist/ladle-inject-custom-addons/assets/563879/235b9c68-a7e5-40f3-b2cc-838f7c608b19"
+    />
     <p>
-      This is a simple example story. Check out the addon buttons at the bottom
-      of the screen to see the magic!
+      This is a working example of the <code>ladle-inject-custom-addons</code>{" "}
+      package. Check out the buttons at the bottom of the screen to see it in
+      action.
+    </p>
+    <p>
+      Learn more at the{" "}
+      <a href="https://github.com/hiddenist/ladle-inject-custom-addons">
+        hiddenist/ladle-inject-custom-addons
+      </a>{" "}
+      GitHub repository!
     </p>
   </div>
 )
@@ -43,8 +70,9 @@ export const StoryWithAddon: Story = () => {
             {elements}
           </>
         }
+        label="Count clicks"
         tooltip="Increment the click count for this story"
-        position={10}
+        position={0}
         badge={clickCount < 10 ? clickCount : "9+"}
         onClick={() => {
           addPlusOne()

--- a/.ladle/example.stories.tsx
+++ b/.ladle/example.stories.tsx
@@ -45,7 +45,7 @@ export const StoryWithAddon: Story = () => {
         }
         tooltip="Increment the click count for this story"
         position={10}
-        badge={true}
+        badge={clickCount < 10 ? clickCount : "9+"}
         onClick={() => {
           addPlusOne()
           setClickCount((c) => c + 1)

--- a/.ladle/example.stories.tsx
+++ b/.ladle/example.stories.tsx
@@ -1,8 +1,12 @@
-import type { Story } from "@ladle/react";
+import React from "react"
+import type { Story } from "@ladle/react"
 
 export const Simple: Story = () => (
-  <ul>
-    <li>Item 1</li>
-    <li>Item 2</li>
-  </ul>
+  <div>
+    <h1>Welcome</h1>
+    <p>
+      This is a simple example story. Check out the addon buttons at the bottom
+      of the screen to see the magic!
+    </p>
+  </div>
 )

--- a/.ladle/style.css
+++ b/.ladle/style.css
@@ -1,0 +1,17 @@
+@keyframes plus-one {
+  0% {
+    opacity: 0;
+    transform: translateY(100%) scale(0.5);
+  }
+  25% {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(0);
+  }
+}

--- a/.ladle/style.css
+++ b/.ladle/style.css
@@ -1,3 +1,13 @@
+.ladle-main {
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.octomoji {
+  font-size: 50px;
+  text-align: "center";
+  margin-bottom: 16px;
+}
+
 @keyframes plus-one {
   0% {
     opacity: 0;

--- a/.ladle/style.css
+++ b/.ladle/style.css
@@ -1,11 +1,51 @@
-.ladle-main {
+body {
   font-family: Arial, Helvetica, sans-serif;
+}
+
+[data-theme="dark"] body {
+  color: #eee;
 }
 
 .octomoji {
   font-size: 50px;
   text-align: "center";
   margin-bottom: 16px;
+}
+
+.home {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.home p {
+  max-width: 80ch;
+}
+
+.home img {
+  max-width: 100%;
+}
+
+.github-badges {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+
+.plus-one {
+  position: absolute;
+  bottom: 100%;
+  animation: plus-one 1s forwards;
+  font-weight: bold;
+  font-size: 12px;
+  color: rgba(10, 60, 90, 0.9);
+  background-color: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+[data-theme="dark"] .plus-one {
+  color: rgba(117, 194, 242, 0.9);
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 @keyframes plus-one {

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const DialogExampleAddon = () => (
 
 ### Icons
 
-Most icon libraries will work for your addon buttons. Check out [react-feather](https://github.com/feathericons/react-feather) if you're not sure where to start!
+Need icons for your addon buttons? Check out [react-feather](https://github.com/feathericons/react-feather) for a great set of icons!
 
 You can also add your own SVGs for your icons. Use `currentColor` for the stroke or fill on the icon to have it use the default hover and active colors. The icons are expected to be 24 by 24 pixels in size.
 
@@ -88,9 +88,12 @@ const MyIcon = () => (
 
 </details>
 
+> [!NOTE]
+> Please be aware that you may encounter issues using certain libraries for your button icons. Material UI icons have been observed causing style issues with production bundles of component story libraries.
+
 ### Button order
 
-If you would like to put your custom addons at a different place in the list, you can pass the `position` property.
+If you would like your custom addon to display in a different position within the addon list, you can pass the `position` property.
 
 ```tsx
 // .ladle/components.tsx
@@ -113,7 +116,7 @@ export const Provider = ({ children }) => (
 
 `AddonButton` utilizes a [React Portal](https://react.dev/reference/react-dom/createPortal) to mount your buttons within the existing Ladle addon list.
 
-> **Warning** <br />
+> [!WARNING]
 > This method of injecting components may not be very stable. Changes to the Ladle package could easily break this in future updates.
 
 ## Questions or contributions

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [Ladle](https://github.com/tajo/ladle) doesn't officially support third party addons yet. Now we can pretend it does!
 
-Confirmed to work up through `@ladle/react` version ^4.10.0.
+Check out working example: https://hiddenist.github.io/ladle-inject-custom-addons/
 
 - [Quick Start](#quick-start)
 - [Customization](#customization)
@@ -22,7 +22,9 @@ Confirmed to work up through `@ladle/react` version ^4.10.0.
 pnpm add ladle-inject-custom-addons
 ```
 
-> **Note** <br />
+This package is confirmed to work with `@ladle/react` up through version ^4.10.0.
+
+> [!NOTE]
 > Replace `pnpm` with `yarn` or `npm` to match what you use for your project. 😉
 
 ### Basic Usage
@@ -51,12 +53,17 @@ const HelloAddon = () => (
   <AddonButton
     icon={<ExampleLadleIcon />}
     onClick={() => alert("hello!")}
+    label="Say hello"
     tooltip="Shows an alert to say hello."
   />
 )
 
 const DialogExampleAddon = () => (
-  <AddonDialogButton icon={<ExampleLadleIcon />} tooltip="Opens a dialog box.">
+  <AddonDialogButton
+    icon={<ExampleLadleIcon />}
+    label="Show dialog"
+    tooltip="Opens a dialog box."
+  >
     <p>Custom text, or more advanced components, will show up in a dialog.</p>
   </AddonDialogButton>
 )
@@ -103,6 +110,7 @@ export const Provider = ({ children }) => (
     <AddonButton
       icon={<ExampleLadleIcon />}
       onClick={() => alert("hello!")}
+      label="Say hello"
       tooltip="Shows an alert to say hello."
       // This button will be third in the addon panel list:
       position={3}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladle-inject-custom-addons",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Adds a button to the Ladle addon bar",
   "files": [
     "dist",
@@ -9,18 +9,18 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs.js"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     },
     "./*": {
       "types": "./dist/components/*.d.ts",
-      "import": "./dist/components/*.js",
-      "require": "./dist/components/*.cjs.js"
+      "import": "./dist/components/*.mjs",
+      "require": "./dist/components/*.js"
     }
   },
   "types": "./dist/index.d.ts",
-  "module": "./dist/index.js",
-  "main": "./dist/index.cjs.js",
+  "module": "./dist/index.mjs",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "tsup && tsc -p tsconfig.build.json",
     "build:watch": "pnpm build --watch",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,6 @@
     },
     "types": ["node"]
   },
-  "include": ["**/*", ".ladle/components.tsx"],
+  "include": ["**/*", ".ladle/components.tsx", ".ladle/example.stories.tsx"],
   "exclude": ["node_modules", "dist", ""]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   format: ["cjs", "esm"],
   entry: ["src/**/*.{ts,tsx}", "!**/*.{test,stories}.{ts,tsx}"],
   splitting: false,
+  minify: true,
   clean: true,
 })


### PR DESCRIPTION
It seems that some of the configuration in the package.json was out of date, so the wrong filenames were referenced in the package.json exports section.

This fixes the config so that `ladle build` can function.

This PR also updates documentation and adds a workflow to build and publish the example Ladle bundle to GitHub pages.